### PR TITLE
revert search engine on uninstall

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ version: 2.1
 jobs:
   Linting:
     docker:
-      - image: cimg/node:16.10.0
+      - image: cimg/python:3.8.8-node
     steps:
       - checkout
       - run:
@@ -23,7 +23,7 @@ jobs:
 
   Firefox integration tests:
     docker:
-      - image: cimg/node:16.10.0
+      - image: cimg/python:3.8.8-node
     steps:
       - checkout
       - run:

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,6 +34,7 @@
         "selenium-webdriver": "^4.0.0-beta.3",
         "svelte": "^3.38.3",
         "tailwindcss": "^2.2.16",
+        "typescript": "^4.7.4",
         "web-ext": "^6.1.0",
         "webextension-polyfill": "^0.8.0"
       },
@@ -9844,11 +9845,10 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.2.tgz",
-      "integrity": "sha512-zZ4hShnmnoVnAHpVHWpTcxdv7dWP60S2FsydQLV8V5PbS3FifjWFFRiHSWpDJahly88PRyV5teTSLoq4eG7mKw==",
+      "version": "4.7.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
+      "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
       "dev": true,
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -18242,11 +18242,10 @@
       }
     },
     "typescript": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.2.tgz",
-      "integrity": "sha512-zZ4hShnmnoVnAHpVHWpTcxdv7dWP60S2FsydQLV8V5PbS3FifjWFFRiHSWpDJahly88PRyV5teTSLoq4eG7mKw==",
-      "dev": true,
-      "peer": true
+      "version": "4.7.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
+      "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
+      "dev": true
     },
     "unbox-primitive": {
       "version": "1.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "@rollup/plugin-typescript": "^8.2.1",
         "@typescript-eslint/eslint-plugin": "^4.19.0",
         "@typescript-eslint/parser": "^4.19.0",
+        "dompurify": "^2.3.8",
         "eslint": "^7.26.0",
         "eslint-plugin-import": "^2.22.1",
         "eslint-plugin-mocha": "^8.1.0",
@@ -2897,6 +2898,12 @@
       "funding": {
         "url": "https://github.com/fb55/domhandler?sponsor=1"
       }
+    },
+    "node_modules/dompurify": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.3.8.tgz",
+      "integrity": "sha512-eVhaWoVibIzqdGYjwsBWodIQIaXFSB+cKDf4cfxLMsK0xiud6SE+/WCVx/Xw/UwQsa4cS3T2eITcdtmTg2UKcw==",
+      "dev": true
     },
     "node_modules/domutils": {
       "version": "2.6.0",
@@ -12796,6 +12803,12 @@
       "requires": {
         "domelementtype": "^2.2.0"
       }
+    },
+    "dompurify": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.3.8.tgz",
+      "integrity": "sha512-eVhaWoVibIzqdGYjwsBWodIQIaXFSB+cKDf4cfxLMsK0xiud6SE+/WCVx/Xw/UwQsa4cS3T2eITcdtmTg2UKcw==",
+      "dev": true
     },
     "domutils": {
       "version": "2.6.0",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "@rollup/plugin-typescript": "^8.2.1",
     "@typescript-eslint/eslint-plugin": "^4.19.0",
     "@typescript-eslint/parser": "^4.19.0",
+    "dompurify": "^2.3.8",
     "eslint": "^7.26.0",
     "eslint-plugin-import": "^2.22.1",
     "eslint-plugin-mocha": "^8.1.0",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "selenium-webdriver": "^4.0.0-beta.3",
     "svelte": "^3.38.3",
     "tailwindcss": "^2.2.16",
+    "typescript": "^4.7.4",
     "web-ext": "^6.1.0",
     "webextension-polyfill": "^0.8.0"
   },

--- a/src/ContentScripts.ts
+++ b/src/ContentScripts.ts
@@ -1,4 +1,4 @@
-import { serpScripts, googleRemoveScript, googleReplaceScript, googleDefaultScript } from "./ContentScriptsImport.js"
+import { serpScripts, googleRemoveScript, googleReplaceScript, googleDefaultScript } from "./contentScriptsImport.js"
 import * as webScience from "@mozilla/web-science";
 import { setExtendedTimeout } from "./Utils.js";
 


### PR DESCRIPTION
This uses the `onShutdown` method of the privileged API to reset the search engine.

@kartkand, I ended up using a pref here instead of WebExtension storage for a few reasons:

- it's awkward to access this storage area from privileged code
- we should try to avoid doing too much async code since this is running during uninstall

As we discussed, this is obviously copying a little bit of existing code, `changeSearchEngine` isn't reachable where it's currently defined so we'd need to refactor a bit if you want to avoid this. 